### PR TITLE
ignore grace notes

### DIFF
--- a/src/PlaybackScheduler.ts
+++ b/src/PlaybackScheduler.ts
@@ -98,9 +98,11 @@ export default class PlaybackScheduler {
     }
 
     for (let entry of currentVoiceEntries) {
-      for (let note of entry.Notes) {
-        this.loaderFutureTicks.add(thisTick + note.Length.RealValue * this.tickDenominator);
-        this.stepQueue.add(thisTick, note);
+      if (!entry.IsGrace) {
+        for (let note of entry.Notes) {
+          this.loaderFutureTicks.add(thisTick + note.Length.RealValue * this.tickDenominator);
+          this.stepQueue.add(thisTick, note);
+        }
       }
     }
 


### PR DESCRIPTION
In [this musicxml file](https://opensheetmusicdisplay.github.io/demo/sheets/Beethoven_AnDieFerneGeliebte.xml), the playback goes crazy in bars 9 and 10 because of the grace notes - it seems like beats are getting skipped somehow. I saw that grace notes are a future work item, but for the time-being would it be okay to omit them entirely?