### PR TITLE
Playback time compression by scheduling cursor steps

### DIFF
--- a/src/PlaybackEngine.ts
+++ b/src/PlaybackEngine.ts
@@ -139,7 +139,14 @@ export default class PlaybackEngine {
   }
 
   async play() {
+    if (!this.scheduler) return;
     await this.ac.resume();
+
+    if (this.state === PlaybackState.PAUSED) {
+      this.setState(PlaybackState.PLAYING);
+      this.scheduler.resume();
+      return;
+    }
 
     if (this.state === PlaybackState.INIT || this.state === PlaybackState.STOPPED) {
       this.cursor.show();
@@ -161,10 +168,12 @@ export default class PlaybackEngine {
 
   pause() {
     this.setState(PlaybackState.PAUSED);
+    if (!this.scheduler) return;
+    // Pause the scheduler first to prevent any further scheduling while we suspend the audio context.
+    // Avoid rewinding scheduler state here; resume should continue from the same stepQueueIndex/tick.
+    this.scheduler.pause();
     this.ac.suspend();
     this.stopPlayers();
-    this.scheduler.setIterationStep(this.currentIterationStep);
-    this.scheduler.pause();
     this.clearTimeouts();
   }
 
@@ -197,7 +206,26 @@ export default class PlaybackEngine {
     let steps = 0;
     while (!this.cursor.Iterator.EndReached) {
       if (this.cursor.Iterator.CurrentVoiceEntries) {
-        this.scheduler.loadNotes(this.cursor.Iterator.CurrentVoiceEntries);
+        // Prefer OSMD's absolute cursor timestamp for the current position to prevent time compression.
+        // Fallback to legacy behavior if timestamp isn't available in the current OSMD build.
+        let timeStampRealValue: number | null = null;
+        try {
+          const iterator: any = this.cursor.Iterator as any;
+          const timeStamp: any = iterator.CurrentTimeStamp ?? iterator.currentTimeStamp ?? null;
+          if (timeStamp && typeof timeStamp.RealValue === "number") {
+            timeStampRealValue = timeStamp.RealValue;
+          } else if (timeStamp && typeof timeStamp.realValue === "number") {
+            timeStampRealValue = timeStamp.realValue;
+          }
+
+          if (typeof timeStampRealValue === "number" && !Number.isFinite(timeStampRealValue)) {
+            timeStampRealValue = null;
+          }
+        } catch {
+          timeStampRealValue = null;
+        }
+
+        this.scheduler.loadNotes(this.cursor.Iterator.CurrentVoiceEntries, timeStampRealValue);
       }
       this.cursor.next();
       ++steps;

--- a/src/PlaybackScheduler.ts
+++ b/src/PlaybackScheduler.ts
@@ -18,6 +18,11 @@ export default class PlaybackScheduler {
   private audioContextStartTime: number = 0;
 
   private schedulerIntervalHandle: number = null;
+  /**
+   * Track all created interval handles so we can reliably clear them on reset.
+   * This prevents duplicate schedulers from running concurrently (perceived tempo increase).
+   */
+  private schedulerIntervalHandles = new Set<number>();
   private scheduleInterval: number = 200; // Milliseconds
   private schedulePeriod: number = 500;
   private tickDenominator: number = 1024;
@@ -51,13 +56,20 @@ export default class PlaybackScheduler {
   }
 
   start() {
-    this.playing = true;
     this.stepQueue.sort();
-    this.audioContextStartTime = this.audioContext.currentTime;
-    this.currentTickTimestamp = this.audioContextTime;
-    if (!this.schedulerIntervalHandle) {
+    if (this.schedulerIntervalHandle === null) {
+      this.playing = true;
+      // Fresh start: reset timebase relative to "now".
+      this.audioContextStartTime = this.audioContext.currentTime;
+      this.currentTickTimestamp = this.audioContextTime;
       this.schedulerIntervalHandle = window.setInterval(() => this.scheduleIterationStep(), this.scheduleInterval);
+      this.schedulerIntervalHandles.add(this.schedulerIntervalHandle);
+      return;
     }
+    // If we're already running an interval (e.g. resume after pause), do NOT reset the timebase.
+    // Just resume scheduling from the current tick/stepQueueIndex.
+    this.playing = true;
+    this.currentTickTimestamp = this.audioContextTime;
   }
 
   setIterationStep(step: number) {
@@ -68,6 +80,8 @@ export default class PlaybackScheduler {
 
   pause() {
     this.playing = false;
+    // Clear bookkeeping so resume can re-schedule cleanly.
+    this.scheduledTicks.clear();
   }
 
   resume() {
@@ -80,13 +94,24 @@ export default class PlaybackScheduler {
     this.currentTick = 0;
     this.currentTickTimestamp = 0;
     this.stepQueueIndex = 0;
-    clearInterval(this.scheduleInterval);
+    this.audioContextStartTime = 0;
+    this.scheduledTicks.clear();
+    // IMPORTANT: clear the *interval handle*, not the interval duration.
+    for (const handle of this.schedulerIntervalHandles) {
+      clearInterval(handle);
+    }
+    this.schedulerIntervalHandles.clear();
     this.schedulerIntervalHandle = null;
   }
 
-  loadNotes(currentVoiceEntries: VoiceEntry[]) {
+  loadNotes(currentVoiceEntries: VoiceEntry[], iteratorTimeStampRealValue?: number | null) {
     let thisTick = this.lastTickOffset;
-    if (this.stepQueue.steps.length > 0) {
+
+    // Use absolute cursor timestamp if available to prevent time compression
+    if (typeof iteratorTimeStampRealValue === "number" && Number.isFinite(iteratorTimeStampRealValue)) {
+      thisTick = this.lastTickOffset + Math.round(iteratorTimeStampRealValue * this.tickDenominator);
+    } else if (this.stepQueue.steps.length > 0) {
+      // Fallback to old heuristic if timestamp unavailable
       thisTick = this.stepQueue.getFirstEmptyTick();
     }
 
@@ -94,7 +119,10 @@ export default class PlaybackScheduler {
       if (!entry.IsGrace) {
         for (let note of entry.Notes) {
           this.stepQueue.addNote(thisTick, note);
-          this.stepQueue.createStep(thisTick + note.Length.RealValue * this.tickDenominator);
+          // Skip creating empty end steps when using absolute timestamps to avoid scheduling noise
+          if (!(typeof iteratorTimeStampRealValue === "number" && Number.isFinite(iteratorTimeStampRealValue))) {
+            this.stepQueue.createStep(thisTick + note.Length.RealValue * this.tickDenominator);
+          }
         }
       }
     }


### PR DESCRIPTION
# Playback time compression bug (OSMD Cursor–based scheduling)

## IMPORTANT DISCLAIMER

This fix was:

- Developed with AI assistance (ChatGPT 5.2 Max).
- Not verified by any musician nor software developer with deep understanding of library.
- The fix appears to work based on initial observations.

## PR overview

- **Description**:
  - Explain the failure mode of first-empty-tick scheduling
  - Explain the use of OSMD absolute timestamp as the authoritative timeline source
  - Mention fallback behavior for compatibility
- **Code changes**:
  - Extend scheduler API to accept an optional `timeStampRealValue`
  - Pass iterator timestamp from the cursor loop into the scheduler
  - In timestamp mode, compute tick from timestamp; skip creating empty end steps
- **Testing guidance**:
  - Validate on scores containing tuplets / dense subdivisions
  - Confirm that wall-clock duration matches musical duration and does not “speed up forever”

## Bug overview

When building an audio playback timeline from OpenSheetMusicDisplay (OSMD) cursor iterations, it’s possible to unintentionally **compress the musical timeline**, causing playback to run **far faster than intended** (e.g., a multi‑minute piece finishing in a few seconds). This presents as an apparent “tempo increase”, but the root issue is **incorrect event timestamping**, not an actual BPM change.

This document describes the bug pattern and a fix that makes scheduling stable across dense notation (tuplets, very short notes, etc.) by using OSMD’s absolute cursor timestamp.

## Symptoms

- Playback begins at the correct tempo, then after a dense passage (often involving tuplets or rapid subdivisions) playback becomes **permanently too fast** until the end.
- The reported BPM (if logged) may remain constant, yet **musical progress (measures/notes) advances far too quickly** relative to wall-clock time.
- The audio scheduler may appear “healthy” (no obvious catch-up/clamping), because the underlying issue is that future events are placed too early on the internal timeline.

## Root cause

### Problem: “first empty tick” scheduling compresses time

A common approach to building a playback queue from cursor steps is:

1. For each cursor position, add all notes at the current “tick” (start time).
2. Create “end ticks” (tick + note duration) as empty steps.
3. For the next cursor position, choose the next tick as the **first empty tick** in the queue.

This heuristic assumes that:

- “the next musical moment” equals “the earliest note end time we’ve seen so far”

That assumption fails for real-world scores because:

- Cursor steps are **not guaranteed** to align with “earliest note end”.
- Dense rhythmic constructs (e.g., tuplets) can create extremely short note ends, introducing empty ticks very close to the current tick.
- Once an early empty tick exists, subsequent cursor steps can be repeatedly placed at or near these early ticks, **collapsing** the intended spacing between musical events.

The result is an internal timeline where later measures are scheduled much earlier than they should be, producing “minutes in seconds”.

### Key observation

OSMD already exposes an **absolute position timestamp** for the cursor iterator:

- `iterator.currentTimeStamp.realValue` (or variant casing depending on build)

This timestamp is expressed in **whole-note units** (fractional), and it represents the correct global position in the score timeline for the current cursor location.

Ignoring this and relying on “first empty tick” is the core bug.

## Fix

### Use OSMD’s absolute cursor timestamp as the scheduler’s time coordinate

Instead of deriving the next scheduling tick from the queue contents, compute the tick directly:

- `tick = offset + round(iteratorTimeStampRealValue * tickDenominator)`

Where:

- `iteratorTimeStampRealValue` is the cursor iterator’s absolute timestamp in whole-note units
- `tickDenominator` is the scheduler’s ticks-per-whole-note constant (e.g., 1024)
- `offset` is any initial padding/hack (optional) used for better first-note alignment

This makes each cursor step’s start time deterministic and proportional to the true score timeline.

### Avoid generating “empty end steps” when using absolute timestamps

When the scheduler is timestamp-driven:

- You no longer need to create empty “end ticks” for each note purely to locate “the next empty tick”.
- Skipping these empty steps reduces noise in the queue and prevents redundant scheduling callbacks.

### Implementation notes (library-agnostic)

- **Backwards compatibility**: if `currentTimeStamp` is unavailable (or `realValue` cannot be read), fall back to the old heuristic to avoid breaking older OSMD builds.
- **Timestamp access**: OSMD property names can differ between builds (e.g., `CurrentTimeStamp` vs `currentTimeStamp`, `RealValue` vs `realValue`). A robust implementation should try both.

## Why this fixes the “fast forever” symptom

With absolute timestamps:

- Each cursor step is scheduled at its true global position.
- A dense passage can contain very short notes, but it **cannot shift** later steps earlier because later steps have their own fixed timestamps.
- The internal timeline remains stable for the remainder of the piece, eliminating permanent acceleration.



